### PR TITLE
fix: swap role and to_role in role derivation API calls

### DIFF
--- a/internal/provider/role_derivations/client.go
+++ b/internal/provider/role_derivations/client.go
@@ -14,7 +14,7 @@ type apiClient struct {
 
 func (c *apiClient) Create(ctx context.Context, plan roleDerivationModel) (roleDerivationModel, error) {
 	derivedRuleCreate := models.DerivedRoleRuleCreate{
-		Role:             plan.Role.ValueString(),
+		Role:             plan.ToRole.ValueString(),
 		OnResource:       plan.OnResource.ValueString(),
 		LinkedByRelation: plan.LinkedByRelation.ValueString(),
 	}
@@ -22,7 +22,7 @@ func (c *apiClient) Create(ctx context.Context, plan roleDerivationModel) (roleD
 	createdGrant, err := c.client.Api.ImplicitGrants.Create(
 		ctx,
 		plan.Resource.ValueString(),
-		plan.ToRole.ValueString(),
+		plan.Role.ValueString(),
 		derivedRuleCreate,
 	)
 
@@ -36,11 +36,11 @@ func (c *apiClient) Create(ctx context.Context, plan roleDerivationModel) (roleD
 
 func (c *apiClient) Read(ctx context.Context, plan roleDerivationModel) (roleDerivationModel, error) {
 	targetRoleRead, err := c.client.Api.ResourceRoles.Get(
-		ctx, plan.Resource.ValueString(), plan.ToRole.ValueString())
+		ctx, plan.Resource.ValueString(), plan.Role.ValueString())
 
 	if err != nil {
 		return roleDerivationModel{},
-			fmt.Errorf("failed getting target role %s/%s: %w", plan.Resource.ValueString(), plan.ToRole.ValueString(), err)
+			fmt.Errorf("failed getting target role %s/%s: %w", plan.Resource.ValueString(), plan.Role.ValueString(), err)
 	}
 
 	if targetRoleRead.GrantedTo == nil {
@@ -49,7 +49,7 @@ func (c *apiClient) Read(ctx context.Context, plan roleDerivationModel) (roleDer
 
 	derivation, found := lo.Find(targetRoleRead.GrantedTo.UsersWithRole, func(item models.DerivedRoleRuleRead) bool {
 		return item.OnResource == plan.OnResource.ValueString() &&
-			item.Role == plan.Role.ValueString() &&
+			item.Role == plan.ToRole.ValueString() &&
 			item.LinkedByRelation == plan.LinkedByRelation.ValueString()
 	})
 
@@ -63,7 +63,7 @@ func (c *apiClient) Read(ctx context.Context, plan roleDerivationModel) (roleDer
 
 func (c *apiClient) Delete(ctx context.Context, plan roleDerivationModel) error {
 	derivedRuleDelete := models.DerivedRoleRuleDelete{
-		Role:             plan.Role.ValueString(),
+		Role:             plan.ToRole.ValueString(),
 		OnResource:       plan.OnResource.ValueString(),
 		LinkedByRelation: plan.LinkedByRelation.ValueString(),
 	}
@@ -71,6 +71,6 @@ func (c *apiClient) Delete(ctx context.Context, plan roleDerivationModel) error 
 	return c.client.Api.ImplicitGrants.Delete(
 		ctx,
 		plan.Resource.ValueString(),
-		plan.ToRole.ValueString(),
+		plan.Role.ValueString(),
 		derivedRuleDelete)
 }

--- a/internal/provider/role_derivations/model.go
+++ b/internal/provider/role_derivations/model.go
@@ -17,9 +17,9 @@ func tfModelFromDerivedRoleRuleRead(plan roleDerivationModel, m models.DerivedRo
 	r := roleDerivationModel{}
 
 	r.Resource = plan.Resource
-	r.ToRole = plan.ToRole
+	r.Role = plan.Role
 	r.OnResource = types.StringValue(m.OnResource)
-	r.Role = types.StringValue(m.Role)
+	r.ToRole = types.StringValue(m.Role)
 	r.LinkedByRelation = types.StringValue(m.LinkedByRelation)
 
 	return r

--- a/internal/provider/role_resource_test.go
+++ b/internal/provider/role_resource_test.go
@@ -303,3 +303,69 @@ func TestResources(t *testing.T) {
 		},
 	})
 }
+
+// TestRoleDerivation is a focused regression test for issue #30: applying a
+// permitio_role_derivation must succeed when the role and to_role keys differ
+// between the two resources. It mirrors the reported scenario (an admin role on
+// "file" deriving a distinctly-keyed admin role on the parent "folder"). With the
+// role/to_role mapping reversed (the pre-fix behaviour) the Permit API returns a
+// 404, so this test fails if the fix in role_derivations/client.go is reverted.
+func TestRoleDerivation(t *testing.T) {
+	testID := fmt.Sprintf("test-%d-%d", time.Now().Unix(), rand.Intn(10000))
+	resource.Test(t, resource.TestCase{
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				Config: providerConfig + fmt.Sprintf(`
+				resource "permitio_resource" "file" {
+					key  = "file-%s"
+					name = "file-%s"
+					actions = {
+						"read" = { "name" = "Read" }
+					}
+					attributes = {}
+				}
+				resource "permitio_resource" "folder" {
+					key  = "folder-%s"
+					name = "folder-%s"
+					actions = {
+						"read" = { "name" = "Read" }
+					}
+					attributes = {}
+				}
+				resource "permitio_relation" "parent" {
+					key              = "parent-%s"
+					name             = "parent of"
+					subject_resource = permitio_resource.folder.key
+					object_resource  = permitio_resource.file.key
+				}
+				resource "permitio_role" "fileAdmin" {
+					key         = "admin-%s"
+					name        = "File Administrator"
+					permissions = ["read"]
+					resource    = permitio_resource.file.key
+				}
+				resource "permitio_role" "folderAdmin" {
+					key         = "folder-admin-%s"
+					name        = "Folder Administrator"
+					permissions = ["read"]
+					resource    = permitio_resource.folder.key
+				}
+				resource "permitio_role_derivation" "folderFileAdmin" {
+					resource    = permitio_resource.file.key
+					role        = permitio_role.fileAdmin.key
+					on_resource = permitio_resource.folder.key
+					to_role     = permitio_role.folderAdmin.key
+					linked_by   = permitio_relation.parent.key
+				}`, testID, testID, testID, testID, testID, testID, testID),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr("permitio_role_derivation.folderFileAdmin", "role", fmt.Sprintf("admin-%s", testID)),
+					resource.TestCheckResourceAttr("permitio_role_derivation.folderFileAdmin", "to_role", fmt.Sprintf("folder-admin-%s", testID)),
+					resource.TestCheckResourceAttr("permitio_role_derivation.folderFileAdmin", "resource", fmt.Sprintf("file-%s", testID)),
+					resource.TestCheckResourceAttr("permitio_role_derivation.folderFileAdmin", "on_resource", fmt.Sprintf("folder-%s", testID)),
+					resource.TestCheckResourceAttr("permitio_role_derivation.folderFileAdmin", "linked_by", fmt.Sprintf("parent-%s", testID)),
+				),
+			},
+		},
+	})
+}


### PR DESCRIPTION
## Summary

Fixes #30 — `permitio_role_derivation` fails when the `role` and `to_role` keys differ between the
two resources. With identical keys the bug is invisible, which is why it went unnoticed.

## Root cause

The `role`/`to_role` mapping was wrong in **two** places that have to agree:

1. **`client.go`** builds the Implicit Grants API call. The URL `roleId` and the request body `Role`
   were swapped, so the API looked up a role on the wrong resource and returned **404** whenever the
   keys differed (Create / Read / Delete were all affected).
2. **`model.go`** maps the API response back into Terraform state. It populated `role` from the API's
   *derived-role* field, so even after correcting the API call the provider returned an
   **inconsistent result** — `role` ended up holding the `to_role` value — which Terraform rejects
   with *"Provider produced inconsistent result after apply"*.

Fixing only the API call is not enough; both files are required for the resource to apply cleanly.

## What changed

- `internal/provider/role_derivations/client.go` — swap `role`/`to_role` in the URL `roleId` and the
  request body across Create / Read / Delete.
- `internal/provider/role_derivations/model.go` — set `role` from the granting role that was queried
  (`plan.Role`) and `to_role` from the rule returned by the API, so post-apply state matches config.
- `internal/provider/role_resource_test.go` — add `TestRoleDerivation`, a focused acceptance test
  that reproduces #30 with **distinct** keys (`admin` on `file` deriving `folder-admin` on the parent
  `folder`) and asserts the created derivation. The pre-existing derivation step used identical keys
  and an empty `Check`, which masked the bug.

## Verification (live Permit.io API, `TF_ACC=1`)

| State | `TestRoleDerivation` |
|---|---|
| Upstream (no fix) | **fails — 404 on create** (reproduces #30) |
| `client.go` swap only | create succeeds, but Terraform errors: *inconsistent result* (`.role` = `to_role` value) |
| **This PR (`client.go` + `model.go`)** | **passes** — create, consistent state, and destroy all succeed |

Reverting the fix makes the new test fail, so it guards the behaviour. Also green locally:
`go build ./...`, `go vet ./...`, `golangci-lint run ./...` (repo config), `gofmt`.

## Notes / scope

- Rebased on `main`; **no `go.mod`/`go.sum` changes**, no unrelated edits.
- The acceptance test needs `TF_ACC=1` + `PERMITIO_API_KEY`; as with the existing suite, fork PRs
  require a maintainer to approve the workflow run.
- `security/snyk (permit)` ERRORs on fork PRs (org token/quota) and is unrelated to this change.

Fixes #30
