### PR TITLE
fix: detect out-of-band deletion of condition set rules and resource instances

### DIFF
--- a/internal/provider/common/errors.go
+++ b/internal/provider/common/errors.go
@@ -1,0 +1,13 @@
+package common
+
+import "strings"
+
+// IsNotFoundErr reports whether err represents a "not found" response from the
+// Permit API. The API returns this in a few textual forms depending on the
+// endpoint (for example "404 Not Found"), so the match is case-insensitive.
+func IsNotFoundErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "not found")
+}

--- a/internal/provider/common/errors_test.go
+++ b/internal/provider/common/errors_test.go
@@ -1,0 +1,28 @@
+package common
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestIsNotFoundErr(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		// The shape the SDK returns on a 404 - note the mixed casing.
+		{"api 404", errors.New("ErrorCode: NotFound, ErrorType: API_ERROR, Message: 404 Not Found"), true},
+		{"synthesized", errors.New("role assignment not found"), true},
+		{"unrelated", errors.New("ErrorCode: Forbidden, Message: 403 Forbidden"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsNotFoundErr(tt.err); got != tt.want {
+				t.Errorf("IsNotFoundErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/conditionset_rules/client.go
+++ b/internal/provider/conditionset_rules/client.go
@@ -2,6 +2,7 @@ package conditionsetrules
 
 import (
 	"context"
+	"fmt"
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/permitio/permit-golang/pkg/permit"
 )
@@ -21,7 +22,7 @@ type ConditionSetRuleClient struct {
 }
 
 func (c *ConditionSetRuleClient) Read(ctx context.Context, data ConditionSetRuleModel) (ConditionSetRuleModel, error) {
-	_, err := c.client.Api.ConditionSets.ListSetPermissions(
+	rules, err := c.client.Api.ConditionSets.ListSetPermissions(
 		ctx,
 		data.UserSet.ValueString(),
 		data.Permission.ValueString(),
@@ -31,6 +32,18 @@ func (c *ConditionSetRuleClient) Read(ctx context.Context, data ConditionSetRule
 	if err != nil {
 		return ConditionSetRuleModel{}, err
 	}
+
+	// The list is filtered server-side by user_set/permission/resource_set, so an
+	// empty result means the rule was removed outside of Terraform.
+	if len(rules) == 0 {
+		return ConditionSetRuleModel{}, fmt.Errorf("condition set rule not found")
+	}
+
+	rule := rules[0]
+	data.Id = types.StringValue(rule.Id)
+	data.OrganizationId = types.StringValue(rule.OrganizationId)
+	data.ProjectId = types.StringValue(rule.ProjectId)
+	data.EnvironmentId = types.StringValue(rule.EnvironmentId)
 
 	return data, nil
 }

--- a/internal/provider/conditionset_rules/client.go
+++ b/internal/provider/conditionset_rules/client.go
@@ -3,6 +3,8 @@ package conditionsetrules
 import (
 	"context"
 	"fmt"
+	"strings"
+
 	"github.com/hashicorp/terraform-plugin-framework/types"
 	"github.com/permitio/permit-golang/pkg/permit"
 )
@@ -25,7 +27,7 @@ func (c *ConditionSetRuleClient) Read(ctx context.Context, data ConditionSetRule
 	rules, err := c.client.Api.ConditionSets.ListSetPermissions(
 		ctx,
 		data.UserSet.ValueString(),
-		data.Permission.ValueString(),
+		permissionFilterValue(data.Permission.ValueString()),
 		data.ResourceSet.ValueString(),
 	)
 
@@ -74,4 +76,15 @@ func (c *ConditionSetRuleClient) Delete(ctx context.Context, rulePlan *Condition
 		rulePlan.Permission.ValueString(),
 		rulePlan.ResourceSet.ValueString(),
 	)
+}
+
+// permissionFilterValue normalizes a permission for the ListSetPermissions
+// filter, which matches on the action key or the resource-action id but not the
+// "{resource_key}:{action_key}" form. Strip the resource prefix so live rules
+// aren't read as deleted; ids and bare action keys pass through unchanged.
+func permissionFilterValue(permission string) string {
+	if _, action, found := strings.Cut(permission, ":"); found {
+		return action
+	}
+	return permission
 }

--- a/internal/provider/conditionset_rules/client_test.go
+++ b/internal/provider/conditionset_rules/client_test.go
@@ -1,0 +1,25 @@
+package conditionsetrules
+
+import "testing"
+
+func TestPermissionFilterValue(t *testing.T) {
+	tests := []struct {
+		name       string
+		permission string
+		want       string
+	}{
+		{"resource action key", "document:read", "read"},
+		{"workspace action key", "ws:access", "access"},
+		{"bare action key", "read", "read"},
+		// Resource-action ids have no colon and must pass through untouched.
+		{"resource action id", "a1b2c3d4e5f6", "a1b2c3d4e5f6"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := permissionFilterValue(tt.permission); got != tt.want {
+				t.Errorf("permissionFilterValue(%q) = %q, want %q", tt.permission, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/provider/conditionset_rules/resource.go
+++ b/internal/provider/conditionset_rules/resource.go
@@ -9,6 +9,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/permitio/permit-golang/pkg/permit"
+	"github.com/permitio/terraform-provider-permit-io/internal/provider/common"
 	"strings"
 )
 
@@ -147,6 +148,11 @@ func (c *ConditionSetRuleResource) Read(ctx context.Context, req resource.ReadRe
 	state, err := c.client.Read(ctx, data)
 
 	if err != nil {
+		// If the rule no longer exists in Permit, drop it from state so it is recreated.
+		if common.IsNotFoundErr(err) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
 		resp.Diagnostics.AddError(
 			"Unable to Read Condition Set Rule",
 			fmt.Sprintf("Unable to read condition set rule: %s, Error: %s", data.Id.String(), err.Error()),

--- a/internal/provider/resource_instances/resource.go
+++ b/internal/provider/resource_instances/resource.go
@@ -108,7 +108,7 @@ func (r *ResourceInstanceResource) Read(ctx context.Context, request resource.Re
 	instanceRead, err := r.client.Read(ctx, model.Key.ValueString(), model.Resource.ValueString())
 
 	if err != nil {
-		if strings.Contains(err.Error(), "not found") {
+		if common.IsNotFoundErr(err) {
 			response.State.RemoveResource(ctx)
 			return
 		}


### PR DESCRIPTION
While auditing drift detection in our setup I ran into two resources that don't notice when the underlying object is deleted outside of Terraform (UI or a direct API call). In both cases the next plan is wrong, and re-applying doesn't fix it.

## permitio_condition_set_rule

`Read` in `conditionset_rules/client.go` calls `ListSetPermissions` but throws the result away and returns the prior state:

```go
_, err := c.client.Api.ConditionSets.ListSetPermissions(...)
if err != nil {
    return ConditionSetRuleModel{}, err
}
return data, nil
```

So if a rule is removed in the UI, `plan` reports no changes and `apply` won't bring it back. I changed `Read` to look at the (server-side filtered) result, return a not-found error when it comes back empty, and have the resource remove it from state so it gets recreated. This is the same approach `role_assignment` already uses.

## permitio_resource_instance

This one already tries to handle a deleted instance:

```go
if strings.Contains(err.Error(), "not found") {
    response.State.RemoveResource(ctx)
    return
}
```

but on a 404 the SDK returns `ErrorCode: NotFound, ErrorType: API_ERROR, Message: 404 Not Found`, which has no lowercase `not found` substring, so the branch never fires. Deleting a resource instance out of band then makes every later plan fail with `Error: Unable to read resource instance ... 404 Not Found`, and the whole module stays stuck until you recreate the instance by hand. This looks like the same root cause as #61.

I moved the not-found check into a small `common.IsNotFoundErr` helper that compares case-insensitively and use it in both resources.

## Testing

`go build ./...`, `go vet ./...` and `go test ./...` all pass. Added a unit test for the helper that covers the exact 404 string the SDK produces. I also confirmed the behaviour against a live environment: before the change, deleting a rule gave an empty plan and deleting an instance broke planning; after, both come back as a recreate.
